### PR TITLE
Switch Auth call to use SSL

### DIFF
--- a/UntappdClient.js
+++ b/UntappdClient.js
@@ -151,7 +151,7 @@ var UntappdClient = function(debug) {
 	that.getUserAuthenticationURL = function(returnRedirectionURL) {
 		if (returnRedirectionURL===undefined || returnRedirectionURL===null) throw new Error("returnRedirectionURL cannot be undefined or null.");
 		if (!hasId() || !hasSecret()) throw new Error("UntappdClient.getUserAuthenticationURL requires a ClientId/ClientSecret pair.");
-		return "http://untappd.com/oauth/authenticate/?client_id="+id+"&response_type=token&redirect_url="+returnRedirectionURL;
+		return "https://untappd.com/oauth/authenticate/?client_id="+id+"&response_type=token&redirect_url="+returnRedirectionURL;
 	};	
 	
 	//this is for server-side, Step 1 - OAUTH Authentication


### PR DESCRIPTION
Received this email and was digging through our Hubot script to ensure everything would continue working. This appears to be the only instance where SSL is not being used.

---

>As an Untappd API developer, we wanted to inform you that you will need to update your application to use our secure, HTTPS API endpoint (https://api.untappd.com). We will be discontinuing our standard HTTP API endpoint on 2/1/15. This will require you to update your code for your application to change the http:// protocol to https://.
>
>After 2/1/15, your API key will no longer work over HTTP and return a 500 HTTP error. The security of the Untappd community is extremely important to us and this change will help keep things safer.
>
>We recommend that you join our API Developer Group at http://untpd.it/apigroup for up the information about the API.
>
>If you have any questions or concerns, please visit our API Developer group or http://help.untappd.com.
>
>Thanks,
>The Untappd Team