### PR TITLE
Add try/catch around JSON.parse

### DIFF
--- a/UntappdClient.js
+++ b/UntappdClient.js
@@ -108,7 +108,12 @@ var UntappdClient = function(debug) {
 			response.on("end",function(incoming){
 				if (debug) console.log("node-untappd: end: ",incoming?incoming.length:0);
 				data += incoming?incoming:"";
-				var obj = JSON.parse(data);
+				try{
+					var obj = JSON.parse(data);
+				}catch(e){
+					callback.call(that, e)
+					return
+				}
 				callback.call(that,null,obj);
 			});
 			response.on("error",function(){

--- a/__tests__/Request.js
+++ b/__tests__/Request.js
@@ -1,0 +1,34 @@
+var sinon = require('sinon')
+var PassThrough = require('stream').PassThrough;
+var http = require('http')
+var UntappdClient = require('../UntappdClient');
+ 
+describe('Requests', () => {
+	beforeEach(() => {
+		this.request = sinon.stub(http, 'request');
+	})
+
+	afterEach(() => {
+		http.request.restore();
+	})
+
+	it('Handles parse errors', () => {
+		var response = new PassThrough();
+		response.write('Something that is not JSON');
+		response.end()
+
+		var request = new PassThrough();
+
+		this.request.callsArgWith(1, response).returns(request)
+
+		var untappd = new UntappdClient();
+		untappd.setClientSecret('fake secret')
+		untappd.setClientId('fake id')
+
+		untappd.beerInfo(function(err, result){
+			if(err){
+				expect(err).not.toBeNull()
+			}
+		}, {BID : 12345})
+	})
+})

--- a/package.json
+++ b/package.json
@@ -1,12 +1,33 @@
 {
   "author": "Glen R. Goodwin (http://www.arei.net)",
   "name": "node-untappd",
-  "keywords": [ "untappd","api","beer","node-untappd","untapped","brew","brewery","untapped","microbrew","micro-brew","micro brew","craft beer","yum","drunk","drunken","trashed","lindsey lohan","wasted","bombed","innebriated" ],
+  "keywords": [
+    "untappd",
+    "api",
+    "beer",
+    "node-untappd",
+    "untapped",
+    "brew",
+    "brewery",
+    "untapped",
+    "microbrew",
+    "micro-brew",
+    "micro brew",
+    "craft beer",
+    "yum",
+    "drunk",
+    "drunken",
+    "trashed",
+    "lindsey lohan",
+    "wasted",
+    "bombed",
+    "innebriated"
+  ],
   "description": "NodeJS API to the Untappd Service",
   "version": "0.4.1",
   "homepage": "http://github.com/arei/node-untappd",
   "bugs": {
-        "url": "http://github.com/arei/node-untappd/issues"
+    "url": "http://github.com/arei/node-untappd/issues"
   },
   "licenses": [
     {
@@ -14,6 +35,10 @@
       "url": "http://github.com/arei/node-untappd/blob/master/LICENSE.txt"
     }
   ],
+  "scripts" : {
+    "test" : "./node_modules/.bin/jest",
+    "test-debug": "node debug --harmony ./node_modules/jest-cli/bin/jest.js --runInBand"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/arei/node-untappd.git"
@@ -23,6 +48,10 @@
     "node": ">=0.6.11"
   },
   "dependencies": {},
-  "devDependencies": {},
+  "devDependencies": {
+    "jest": "^19.0.2",
+    "jest-cli": "^19.0.2",
+    "sinon": "^2.1.0"
+  },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
This PR adds a `try`/`catch` around `JSON.parse` in the `req` function.  `repsonse` doesn't automatically trap exceptions and emit an `error` event as one might expect.  This explicitly traps the exception and calls the callback with an error to avoid any uncaught exceptions.