### PR TITLE
Align example and README to the Untappd and JS APIs

### DIFF
--- a/Example.js
+++ b/Example.js
@@ -26,7 +26,7 @@ untappd.setClientId(clientId);
 untappd.setClientSecret(clientSecret);
 
 // EXAMPLE - List last 25 recent checkins of the given user
-untappd.userFeed(function(err,obj){
+untappd.userActivityFeed(function(err,obj){
 	if (debug) console.log(err,obj);
 	if (obj && obj.response && obj.response.checkins && obj.response.checkins.items) {
 		var beers = obj.response.checkins.items.forEach(function(checkin){

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Set your credientials
 Executing API calls, for example:
 
  	var lookupuser = "[ some user name ]";
-	untappd.userFeed(function(err,obj){
+	untappd.userActivityFeed(function(err,obj){
 		var beers = obj.results.forEach(function(checkin){
 			console.log("\n"+username,"drank",checkin.beer_name);
 			console.log("by",checkin.brewery_name);


### PR DESCRIPTION
The example in the README and in `Example.js` are out-of sync with what is offered in the JS API within `UntappdClient.js` and is still provided by Untappd directly.

This PR adjusts the calls from the non-existent `userFeed()` to `userActivityFeed()`.