### PR TITLE
Fix pendingFriends call by including data argument

### DIFF
--- a/UntappdClient.js
+++ b/UntappdClient.js
@@ -358,7 +358,7 @@ var UntappdClient = function(debug) {
 	};
 
 	// https://untappd.com/api/docs#pendingfriends
-	that.pendingFriends = function(callback) {
+	that.pendingFriends = function(callback, data) {
 		data = data || {}
 		validate(callback, "callback");
 		authorized(true);


### PR DESCRIPTION
Fixes a `ReferenceError` when attempting to use this method. While this is unused in most contexts, having it available allows the user to pass in a `limit` and `offset` parameter if needed.

Fixes #20